### PR TITLE
Added ssh workaround for getting ssh fingerprint

### DIFF
--- a/notebooks/05_data_transfer.qmd
+++ b/notebooks/05_data_transfer.qmd
@@ -371,6 +371,20 @@ sftp <your-unikey>@research-data-ext.sydney.edu.au
 
 This time, you shouldn't be prompted for a password. You can proceed to transfer data between Gadi and USyd's Artemis/RDS system now on the `copyq`. 
 
+If you get the error "Fatal error: Host key verification failed" you may have to get an "ssh fingerprint" first. Do this by sending an ssh request to the RDS with:
+
+```bash
+ssh <your-unikey>@research-data-ext.sydney.edu.au
+```
+
+Accept that you trust the connection and enter your passowrd. The connection will then close with the following message:
+
+```
+This service allows sftp connections only.
+Connection to research-data-ext.sydney.edu.au closed.
+```
+But now try `lftp` connection again!
+
 :::
 
 


### PR DESCRIPTION
This seems required when setting up ssh keys before using sftp/lftp without password. Otherwise you will get  "Fatal error: Host key verification failed"